### PR TITLE
Bump to 0.4.1; use dedicated activate scripts

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -7,8 +7,8 @@ if "%NEED_SCRIPTS%" == "no" (
 del %SP_DIR%\anaconda_anon_usage\plugin.py
 if not exist %PREFIX%\etc\conda\activate.d mkdir %PREFIX%\etc\conda\activate.d
 if not exist %PREFIX%\python-scripts mkdir %PREFIX%\python-scripts
-copy scripts\post-link.sh %PREFIX%\etc\conda\activate.d\%PKG_NAME%_activate.sh
-copy scripts\post-link.bat %PREFIX%\etc\conda\activate.d\%PKG_NAME%_activate.bat
+copy scripts\activate.sh %PREFIX%\etc\conda\activate.d\%PKG_NAME%_activate.sh
+copy scripts\activate.bat %PREFIX%\etc\conda\activate.d\%PKG_NAME%_activate.bat
 copy scripts\post-link.sh %PREFIX%\python-scripts\.%PKG_NAME%-post-link.sh
 copy scripts\post-link.bat %PREFIX%\python-scripts\.%PKG_NAME%-post-link.bat
 copy scripts\pre-unlink.sh %PREFIX%\python-scripts\.%PKG_NAME%-pre-unlink.sh

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -6,8 +6,8 @@ fi
 rm ${SP_DIR}/anaconda_anon_usage/plugin.py
 mkdir -p "${PREFIX}/etc/conda/activate.d"
 mkdir -p "${PREFIX}/python-scripts"
-cp "scripts/post-link.sh" "${PREFIX}/etc/conda/activate.d/${PKG_NAME}_activate.sh"
-cp "scripts/post-link.bat" "${PREFIX}/etc/conda/activate.d/${PKG_NAME}_activate.bat"
+cp "scripts/activate.sh" "${PREFIX}/etc/conda/activate.d/${PKG_NAME}_activate.sh"
+cp "scripts/activate.bat" "${PREFIX}/etc/conda/activate.d/${PKG_NAME}_activate.bat"
 cp "scripts/post-link.sh" "${PREFIX}/python-scripts/.${PKG_NAME}-post-link.sh"
 cp "scripts/post-link.bat" "${PREFIX}/python-scripts/.${PKG_NAME}-post-link.bat"
 cp "scripts/pre-unlink.sh" "${PREFIX}/python-scripts/.${PKG_NAME}-pre-unlink.sh"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "anaconda-anon-usage" %}
-{% set version = "0.4.0" %}
-{% set sha256 = "e60e3236bc484e75aa4bde85350324d2f28d9996886f0e1087d5f3cdf1a12273" %}
+{% set version = "0.4.1" %}
+{% set sha256 = "c3106180de22ef8126ec07a5a76c274377d0e66e14e2d3aa2e4d662dcc29a8ba" %}
 
 package:
   name: {{ name }}


### PR DESCRIPTION
https://github.com/anaconda/anaconda-anon-usage/pull/33
https://github.com/anaconda/anaconda-anon-usage/issues/32

The upstream repo now supplies dedicated activate.sh and activate.bat scripts, instead of relying on the build process to copy the post-link scripts into those positions. This is the only change between 0.4.0 and 0.4.1.

Here is the source CI for 0.4.1, for reference:
https://github.com/anaconda/anaconda-anon-usage/actions/runs/6209216656