### PR TITLE
Bump to v0.5.0 [PKG-6338]

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "anaconda-anon-usage" %}
-{% set version = "0.4.4" %}
-{% set sha256 = "7c771b42a7c377d9c872929da986926869c433839ad5d3a793d02b9ee340b24c" %}
+{% set version = "0.5.0" %}
+{% set sha256 = "549abbf34472dbdf332009f95e4b1278d7b0d839085a8b95eb6b73e4b3b42b80" %}
 {% set number = 0 %}
 
 package:


### PR DESCRIPTION
anaconda-anon-usage 0.5.0

**Destination channel:** defaults

### Links

- [PKG-6338](https://anaconda.atlassian.net/browse/PKG-6338) 
- [Upstream repository](https://github.com/anaconda/anaconda-anon-usage)
- [Upstream changelog/diff](https://github.com/anaconda/anaconda-anon-usage/compare/0.4.4...0.5.0)

### Explanation of changes:

- Renovate updates
- Fix `conda info` output redaction: https://github.com/anaconda/anaconda-anon-usage/pull/112
- Improved token randomness: https://github.com/anaconda/anaconda-anon-usage/pull/111
- Organization token support: https://github.com/anaconda/anaconda-anon-usage/pull/110
- Updated build matrix: https://github.com/anaconda/anaconda-anon-usage/pull/108

[PKG-6338]: https://anaconda.atlassian.net/browse/PKG-6338?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ