### PR TITLE
Bump to 0.6.1 [PKG-7255]

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,9 +37,11 @@ test:
   requires:
     - conda >=23.7  # [variant=="plugin"]
     - conda >=4.11,<23.7   # [variant=="patch"]
+    - pip
   imports:
     - anaconda_anon_usage
   commands:
+    - pip check
     - conda info
     - conda info --json
     - python -m anaconda_anon_usage.install --expect  # [variant=="patch"]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "anaconda-anon-usage" %}
-{% set version = "0.5.0" %}
-{% set sha256 = "549abbf34472dbdf332009f95e4b1278d7b0d839085a8b95eb6b73e4b3b42b80" %}
+{% set version = "0.6.1" %}
+{% set sha256 = "31182c9ab0f7f1e92c831a6c4d9fd59e922743b38c34956ee33b8dee5d8b6456" %}
 {% set number = 0 %}
 
 package:
@@ -54,6 +54,7 @@ test:
     - conda info --envs
     - python -m anaconda_anon_usage.install --expect  # [variant=="patch"]
     - pytest -v tests/unit
+    - pip install proxyspy
     - python tests/integration/test_config.py
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,25 +37,12 @@ test:
   requires:
     - conda >=23.7  # [variant=="plugin"]
     - conda >=4.11,<23.7   # [variant=="patch"]
-    - pytest
-    - pytest-cov
-  source_files:
-    - tests
   imports:
     - anaconda_anon_usage
   commands:
-    - export ANACONDA_ANON_USAGE_DEBUG=1  # [unix]
-    - export PYTHONUNBUFFERED=1  # [unix]
-    - set ANACONDA_ANON_USAGE_DEBUG=1  # [win]
-    - set PYTHONUNBUFFERED=1 # [win]
-    - conda create -n testchild1 --yes
-    - conda create -n testchild2 --yes
     - conda info
-    - conda info --envs
+    - conda info --json
     - python -m anaconda_anon_usage.install --expect  # [variant=="patch"]
-    - pytest -v tests/unit
-    - pip install proxyspy
-    - python tests/integration/test_config.py
 
 about:
   home: https://github.com/anaconda/anaconda-anon-usage


### PR DESCRIPTION
anaconda-anon-usage 0.6.1

**Destination channel:** defaults

### Links

- [PKG-7255](https://anaconda.atlassian.net/browse/PKG-7255)
- [Upstream repository](https://github.com/anaconda/anaconda-anon-usage)
- Upstream changelog/diffs:
   - https://github.com/anaconda/anaconda-anon-usage/releases/tag/0.6.1
   - https://github.com/anaconda/anaconda-anon-usage/releases/tag/0.6.0

### Explanation of changes:

- Significant improvements in preparation for gateway rollout
- We have reduced the testing in this feedstock due to the complexity of the test environment. Please feel free to review the test suite in the source repo to confirm we're putting this package through its paces very well. The test harness for this package is very complex—here are the runs for 0.6.1 for your inspection: tested on conda 4.11 through 25.1.1, on ubuntu-intel, ubuntu-arm, macos-intel, macos-arm, and windows
https://github.com/anaconda/anaconda-anon-usage/actions/runs/13571193371


[PKG-7255]: https://anaconda.atlassian.net/browse/PKG-7255?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ