### PR TITLE
bump to 0.7

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "anaconda-anon-usage" %}
-{% set version = "0.6.1" %}
-{% set sha256 = "31182c9ab0f7f1e92c831a6c4d9fd59e922743b38c34956ee33b8dee5d8b6456" %}
+{% set version = "0.7.0" %}
+{% set sha256 = "cc8b66a3f5f315b762f22afc0b5c09c404222330c3352a19479f840d0988ae3f" %}
 {% set number = 0 %}
 
 package:


### PR DESCRIPTION
anaconda-anon-usage 0.7

**Destination channel:** defaults

### Links

- [PKG-7608](https://anaconda.atlassian.net/browse/PKG-7608) 
- [Upstream repository](https://github.com/anaconda/anaconda-anon-usage)
- [Upstream changelog/diff](https://github.com/anaconda/anaconda-anon-usage/releases/tag/0.7.0)
- Relevant dependency PRs: none

### Explanation of changes:

- Renovate updates
- Detection and regeneration of cloned client IDs
- Improvements to heartbeat support
- No changes in dependencies.


[PKG-7608]: https://anaconda.atlassian.net/browse/PKG-7608?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ