### PR TITLE
PKG-8340: bump to 0.7.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "anaconda-anon-usage" %}
-{% set version = "0.7.0" %}
-{% set sha256 = "cc8b66a3f5f315b762f22afc0b5c09c404222330c3352a19479f840d0988ae3f" %}
+{% set version = "0.7.1" %}
+{% set sha256 = "951da5afd65994907f56c7f4a3cd421cbe7c6d9d7ed77c8802cdd8f445cd8506" %}
 {% set number = 1 %}
 
 package:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "anaconda-anon-usage" %}
 {% set version = "0.7.1" %}
 {% set sha256 = "951da5afd65994907f56c7f4a3cd421cbe7c6d9d7ed77c8802cdd8f445cd8506" %}
-{% set number = 1 %}
+{% set number = 0 %}
 
 package:
   name: {{ name }}


### PR DESCRIPTION
anaconda-anon-usage 0.7.1

**Destination channel:** defaults

### Links

- [PKG-8340](https://anaconda.atlassian.net/browse/PKG-8340) 
- [Upstream repository](https://github.com/anaconda/anaconda-anon-usage)
- [Upstream changelog/diff](https://github.com/anaconda/anaconda-anon-usage/releases/tag/0.7.1)

### Explanation of changes:

- Support .cloud to .com migration
- Move node locking to sidecar file


[PKG-8340]: https://anaconda.atlassian.net/browse/PKG-8340?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ