### PR TITLE
PKG-9046: Bump to 0.7.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "anaconda-anon-usage" %}
-{% set version = "0.7.1" %}
-{% set sha256 = "951da5afd65994907f56c7f4a3cd421cbe7c6d9d7ed77c8802cdd8f445cd8506" %}
+{% set version = "0.7.2" %}
+{% set sha256 = "b4b6c2d17a2ab7907b0e5e7846d7522f7a09a21c1ddd575aeae55c506b7d4e27" %}
 {% set number = 0 %}
 
 package:


### PR DESCRIPTION
anaconda-anon-usage 0.7.2

**Destination channel:** defaults

### Links

- [PKG-9046](https://anaconda.atlassian.net/browse/PKG-9046) 
- [Upstream repository](https://github.com/anaconda/anaconda-anon-usage)
- [Upstream changelog/diff](https://github.com/anaconda/anaconda-anon-usage/compare/0.7.1...0.7.2)

### Explanation of changes:

- Add support for ANACONDA_AUTH_API_KEY
- Allow org and mch tokens to be supplied by environment variables


[PKG-9046]: https://anaconda.atlassian.net/browse/PKG-9046?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ