### PR TITLE
PKG-9658: version 0.7.3

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,3 +1,3 @@
 variant:
-- patch # [py<312]
+- patch
 - plugin

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ build:
   # variant is slightly preferred by conda's solver.
   number: {{ number + 100 }}  # [variant=="plugin"]
   number: {{ number }}        # [variant=="patch"]
-  skip: True # [py<=36 or variant=="patch" and py>311]
+  skip: True # [variant=="patch" and py>311]
   script_env:
    - NEED_SCRIPTS=no   # [variant=="plugin"]
    - NEED_SCRIPTS=yes  # [variant=="patch"]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "anaconda-anon-usage" %}
-{% set version = "0.7.2" %}
-{% set sha256 = "b4b6c2d17a2ab7907b0e5e7846d7522f7a09a21c1ddd575aeae55c506b7d4e27" %}
+{% set version = "0.7.3" %}
+{% set sha256 = "27e9dcea2137ebb670a71a688397ce3e90cb9b95a88d3aa105a515db8bd468da" %}
 {% set number = 0 %}
 
 package:


### PR DESCRIPTION
anaconda-anon-usage 0.7.3

**Destination channel:** defaults

### Links

- [PKG-9658](https://anaconda.atlassian.net/browse/PKG-9658) 
- [Upstream repository](https://github.com/anaconda/anaconda-anon-usage)
- [Upstream changelog/diff](https://github.com/anaconda/anaconda-anon-usage/compare/0.7.2...0.7.3)

### Explanation of changes:

- Fix to restore node tie behavior on Python 3.13+


[PKG-9658]: https://anaconda.atlassian.net/browse/PKG-9658?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ