### PR TITLE
Version 0.7.4 and noarch

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY313 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,8 @@
 {% set name = "anaconda-anon-usage" %}
-{% set version = "0.7.3" %}
-{% set sha256 = "27e9dcea2137ebb670a71a688397ce3e90cb9b95a88d3aa105a515db8bd468da" %}
+{% set version = "0.7.4" %}
+{% set sha256 = "6b0f10ec0b7b57ef3c1d4c4c710001993f31abd65e41388a63bc6dee2edf5fac" %}
 {% set number = 0 %}
+{% set python_min = "3.8" %}
 
 package:
   name: {{ name }}
@@ -14,28 +15,30 @@ source:
 build:
   # Use a build number difference to ensure that the plugin
   # variant is slightly preferred by conda's solver.
+  noarch: python
   number: {{ number + 100 }}  # [variant=="plugin"]
   number: {{ number }}        # [variant=="patch"]
-  skip: True # [variant=="patch" and py>311]
   script_env:
    - NEED_SCRIPTS=no   # [variant=="plugin"]
    - NEED_SCRIPTS=yes  # [variant=="patch"]
 
 requirements:
   host:
-    - python
+    - python {{ python_min }}
     - setuptools
     - wheel
     - pip
   run:
-    - python
+    - python >={{ python_min }}        # [variant=="plugin"]
+    - python >={{ python_min }},<3.11  # [variant=="patch"]
   run_constrained:
-    - conda >=23.7  # [variant=="plugin"]
+    - conda >=23.7         # [variant=="plugin"]
     - conda >=4.11,<23.7   # [variant=="patch"]
 
 test:
   requires:
-    - conda >=23.7  # [variant=="plugin"]
+    - python {{ python_min }}
+    - conda >=23.7         # [variant=="plugin"]
     - conda >=4.11,<23.7   # [variant=="patch"]
     - pip
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,6 +2,8 @@
 {% set version = "0.7.4" %}
 {% set sha256 = "6b0f10ec0b7b57ef3c1d4c4c710001993f31abd65e41388a63bc6dee2edf5fac" %}
 {% set number = 0 %}
+# We don't support 3.8 anymore, but this package is unique in that we seek
+# to support as wide a range of *existing* conda installations as practical
 {% set python_min = "3.8" %}
 
 package:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -62,3 +62,7 @@ about:
         to package servers during index and package requests. Specifically,
         three randomly generated tokens are appended to the "user agent"
         that Conda already sends with each request.
+
+extra:
+  skip-lints:
+    - avoid_noarch


### PR DESCRIPTION
anaconda-anon-usage 0.7.4

**Destination channel:** defaults

### Links

- [PKG-10374](https://anaconda.atlassian.net/browse/PKG-10374) 
- [Upstream repository](https://github.com/anaconda/anaconda-anon-usage)
- [Upstream changelog/diff](https://github.com/anaconda/anaconda-anon-usage/compare/0.7.3...0.7.4)

### Explanation of changes:

- Fixes to facilitate gated reg
- Conversion to noarch, partly to ensure we can continue to support osx-64 clients with this
- Here's the CI for the upstream source, showing noarch builds tested against a full matrix of conda clients: https://github.com/anaconda/anaconda-anon-usage/actions/runs/18856935634

[PKG-10374]: https://anaconda.atlassian.net/browse/PKG-10374?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ