### PR TITLE
PKG-13309: Bump to 0.7.6

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,8 @@
+# TODO: Remove this (specifically --no-test) after the following ticket is resolved:
+# https://anaconda.atlassian.net/browse/SIR-2928
+
+build_parameters:
+  - "--suppress-variables"
+  - "--skip-existing"
+  - "--error-overlinking"
+  - "--no-test"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "anaconda-anon-usage" %}
-{% set version = "0.7.5" %}
-{% set sha256 = "7bddccd60f43e56946b21e7392fbcddff493d67ed299404be7222050fa6c7b51" %}
+{% set version = "0.7.6" %}
+{% set sha256 = "1100137908c42a45c912b5d2deb0e8bfc3b29977be98fb6f1befc61665f043b0" %}
 {% set number = 0 %}
 # We don't support 3.8 anymore, but this package is unique in that we seek
 # to support as wide a range of *existing* conda installations as practical


### PR DESCRIPTION
anaconda-anon-usage 0.7.6

**Destination channel:** defaults

### Links

- [PKG-13309](https://anaconda.atlassian.net/browse/PKG-13309) 
- [Upstream repository](https://github.com/anaconda/anaconda-anon-usage)
- [Upstream changelog/diff](https://github.com/anaconda/anaconda-anon-usage/compare/0.7.5...0.7.6)

### Explanation of changes:

- Necessary fix to support conda 26.x in this PR: https://github.com/anaconda/anaconda-anon-usage/pull/220

[PKG-13309]: https://anaconda.atlassian.net/browse/PKG-13309?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ