### PR TITLE
Update version to 0.8.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,5 @@
 {% set name = "anaconda-anon-usage" %}
-{% set version = "0.7.6" %}
-{% set sha256 = "1100137908c42a45c912b5d2deb0e8bfc3b29977be98fb6f1befc61665f043b0" %}
+{% set version = "0.8.1" %}
 {% set number = 0 %}
 # We don't support 3.8 anymore, but this package is unique in that we seek
 # to support as wide a range of *existing* conda installations as practical
@@ -12,7 +11,7 @@ package:
 
 source:
   url: https://github.com/anaconda/{{ name }}/archive/refs/tags/{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+  sha256: 822eb9591fbe588e0a42dc55fc685ebc202b6b24ef74597519b8a9518935ac67
 
 build:
   # Use a build number difference to ensure that the plugin

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,6 +17,8 @@ build:
   # Use a build number difference to ensure that the plugin
   # variant is slightly preferred by conda's solver.
   noarch: python
+  entry_points:
+   - anaconda-anon-usage = anaconda_anon_usage.main:main
   number: {{ number + 100 }}  # [variant=="plugin"]
   number: {{ number }}        # [variant=="patch"]
   script_env:
@@ -44,9 +46,13 @@ test:
     - pip
   imports:
     - anaconda_anon_usage
+    - anaconda_anon_usage.main
+    - anaconda_anon_usage.patch
+    - anaconda_anon_usage.tokens
   commands:
     - pip check
-    - conda info
+    - anaconda-anon-usage --version
+    - anaconda-anon-usage --help
     - conda info --json
     - python -m anaconda_anon_usage.install --expect  # [variant=="patch"]
 


### PR DESCRIPTION
anaconda-anon-usage 0.8.1

**Destination channel:**  defaults

### Links

- [PKG-14658](https://anaconda.atlassian.net/browse/PKG-14658) 
- [Upstream repository](https://github.com/anaconda/anaconda-anon-usage)

### Explanation of changes:
- New version number


[PKG-14658]: https://anaconda.atlassian.net/browse/PKG-14658?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ